### PR TITLE
Add initial GCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# 🛰️ ChirpStack Full Stack Deployment
+# 🛰️ ChirpStack Full Stack Deployment on Google Cloud
 
-Deploy a production-ready ChirpStack instance with all its core dependencies using OpenTofu. This package includes:
+This project contains OpenTofu configurations to deploy a full ChirpStack stack on **Google Cloud Platform (GCP)**. The deployment includes:
 
 - **ChirpStack Network Server**
 - **ChirpStack Application Server**
-- **PostgreSQL** for persistent storage
-- **Redis** for stream and device session caching
-- **Mosquitto (MQTT Broker)** for device uplink/downlink messaging
-- **Load Balancer** for routing external traffic
+- **PostgreSQL** backed by Cloud SQL
+- **Redis** using Memorystore
+- **Mosquitto** MQTT broker on a Compute Instance
+- **HTTP Load Balancer**
 
-> ⚡ Deploy to Digital Ocean
+The legacy DigitalOcean configuration is still available in `main.tf`. To deploy on GCP use the `gcp_main.tf` entry point and provide the required variables.

--- a/gcp_main.tf
+++ b/gcp_main.tf
@@ -1,0 +1,108 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0"
+    }
+  }
+}
+
+variable "gcp_project" { type = string }
+variable "gcp_region" { type = string }
+variable "gcp_zone" { type = string }
+
+variable "network_name" { type = string }
+
+variable "db_name" { type = string }
+variable "db_version" { type = string }
+variable "db_tier" { type = string }
+variable "db_password" { type = string }
+
+variable "redis_name" { type = string }
+variable "redis_tier" { type = string }
+variable "redis_memory_size_gb" { type = number }
+
+variable "mosquitto_name" { type = string }
+variable "mosquitto_machine_type" { type = string }
+variable "mosquitto_image" { type = string }
+variable "mosquitto_username" { type = string }
+variable "mosquitto_password" { type = string }
+
+variable "chirpstack_count" { type = number }
+variable "chirpstack_machine_type" { type = string }
+variable "chirpstack_image" { type = string }
+
+variable "loadbalancer_name" { type = string }
+
+provider "google" {
+  project = var.gcp_project
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+}
+
+module "network" {
+  source       = "./modules/gcp_network"
+  project      = var.gcp_project
+  region       = var.gcp_region
+  network_name = var.network_name
+}
+
+module "postgres" {
+  source      = "./modules/gcp_postgres"
+  project     = var.gcp_project
+  region      = var.gcp_region
+  db_name     = var.db_name
+  db_version  = var.db_version
+  tier        = var.db_tier
+  db_password = var.db_password
+}
+
+module "redis" {
+  source          = "./modules/gcp_redis"
+  project         = var.gcp_project
+  region          = var.gcp_region
+  name            = var.redis_name
+  tier            = var.redis_tier
+  memory_size_gb  = var.redis_memory_size_gb
+}
+
+module "mosquitto" {
+  source        = "./modules/gcp_mosquitto"
+  project       = var.gcp_project
+  zone          = var.gcp_zone
+  name          = var.mosquitto_name
+  machine_type  = var.mosquitto_machine_type
+  source_image  = var.mosquitto_image
+  network       = module.network.network
+  username      = var.mosquitto_username
+  password      = var.mosquitto_password
+}
+
+module "chirpstack" {
+  source            = "./modules/gcp_chirpstack"
+  project           = var.gcp_project
+  zone              = var.gcp_zone
+  count             = var.chirpstack_count
+  machine_type      = var.chirpstack_machine_type
+  source_image      = var.chirpstack_image
+  network           = module.network.network
+  mosquitto_host    = module.mosquitto.mosquitto_host
+  mosquitto_port    = module.mosquitto.mosquitto_port
+  mosquitto_username = var.mosquitto_username
+  mosquitto_password = var.mosquitto_password
+  postgres_host     = module.postgres.host
+  postgres_port     = module.postgres.port
+  postgres_db_name  = module.postgres.db_name
+  postgres_user     = module.postgres.user
+  postgres_password = module.postgres.password
+  redis_host        = module.redis.host
+}
+
+module "loadbalancer" {
+  source              = "./modules/gcp_loadbalancer"
+  project             = var.gcp_project
+  region              = var.gcp_region
+  name                = var.loadbalancer_name
+  instance_self_links = module.chirpstack.instance_self_links
+}
+

--- a/modules/gcp_chirpstack/main.tf
+++ b/modules/gcp_chirpstack/main.tf
@@ -1,0 +1,52 @@
+variable "project" { type = string }
+variable "zone" { type = string }
+variable "count" { type = number }
+variable "machine_type" { type = string }
+variable "source_image" { type = string }
+variable "network" { type = string }
+
+variable "mosquitto_host" { type = string }
+variable "mosquitto_port" { type = number }
+variable "mosquitto_username" { type = string }
+variable "mosquitto_password" { type = string }
+
+variable "postgres_host" { type = string }
+variable "postgres_port" { type = number }
+variable "postgres_db_name" { type = string }
+variable "postgres_user" { type = string }
+variable "postgres_password" { type = string }
+
+variable "redis_host" { type = string }
+variable "redis_password" { type = string }
+
+resource "google_compute_instance" "chirpstack" {
+  count        = var.count
+  name         = "chirpstack-${count.index}" 
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params { image = var.source_image }
+  }
+
+  network_interface {
+    network = var.network
+    access_config {}
+  }
+
+  metadata_startup_script = <<-EOT
+    #!/bin/bash
+    apt-get update
+    apt-get install -y docker.io docker-compose git
+    git clone https://github.com/tofuhubhq/chirpstack-docker.git /opt/chirpstack
+    cd /opt/chirpstack
+    export MQTT_BROKER_HOST=${var.mosquitto_username}:${var.mosquitto_password}@${var.mosquitto_host}
+    export POSTGRESQL_HOST=postgres://${var.postgres_user}:${var.postgres_password}@${var.postgres_host}:${var.postgres_port}/${var.postgres_db_name}?sslmode=disable
+    export REDIS_HOST=default:${var.redis_password}@${var.redis_host}
+    docker-compose up -d
+  EOT
+}
+
+output "instance_self_links" {
+  value = google_compute_instance.chirpstack[*].self_link
+}

--- a/modules/gcp_loadbalancer/main.tf
+++ b/modules/gcp_loadbalancer/main.tf
@@ -1,0 +1,21 @@
+variable "project" { type = string }
+variable "region" { type = string }
+variable "name" { type = string }
+variable "instance_self_links" { type = list(string) }
+
+resource "google_compute_target_pool" "default" {
+  name     = var.name
+  region   = var.region
+  instances = var.instance_self_links
+}
+
+resource "google_compute_forwarding_rule" "default" {
+  name        = var.name
+  region      = var.region
+  target      = google_compute_target_pool.default.self_link
+  port_range  = "80"
+}
+
+output "ip" {
+  value = google_compute_forwarding_rule.default.ip_address
+}

--- a/modules/gcp_mosquitto/main.tf
+++ b/modules/gcp_mosquitto/main.tf
@@ -1,0 +1,39 @@
+variable "project" { type = string }
+variable "zone" { type = string }
+variable "name" { type = string }
+variable "machine_type" { type = string }
+variable "source_image" { type = string }
+variable "network" { type = string }
+variable "username" { type = string }
+variable "password" { type = string }
+
+resource "google_compute_instance" "mosquitto" {
+  name         = var.name
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = var.source_image
+    }
+  }
+
+  network_interface {
+    network = var.network
+    access_config {}
+  }
+
+  metadata_startup_script = <<-EOT
+    #!/bin/bash
+    apt-get update
+    apt-get install -y mosquitto
+    mosquitto_passwd -b -c /etc/mosquitto/passwd ${var.username} ${var.password}
+    echo "allow_anonymous false" > /etc/mosquitto/conf.d/auth.conf
+    echo "password_file /etc/mosquitto/passwd" >> /etc/mosquitto/conf.d/auth.conf
+    systemctl enable mosquitto
+    systemctl restart mosquitto
+  EOT
+}
+
+output "mosquitto_host" { value = google_compute_instance.mosquitto.network_interface[0].access_config[0].nat_ip }
+output "mosquitto_port" { value = 1883 }

--- a/modules/gcp_network/main.tf
+++ b/modules/gcp_network/main.tf
@@ -1,0 +1,24 @@
+variable "project" { type = string }
+variable "region" { type = string }
+variable "network_name" { type = string }
+
+resource "google_compute_network" "main" {
+  name                    = var.network_name
+  auto_create_subnetworks = true
+}
+
+resource "google_compute_firewall" "ssh" {
+  name    = "${var.network_name}-ssh"
+  network = google_compute_network.main.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "network" {
+  value = google_compute_network.main.name
+}

--- a/modules/gcp_postgres/main.tf
+++ b/modules/gcp_postgres/main.tf
@@ -1,0 +1,33 @@
+variable "project" { type = string }
+variable "region" { type = string }
+variable "db_name" { type = string }
+variable "db_version" { type = string }
+variable "tier" { type = string }
+variable "db_password" { type = string }
+
+resource "google_sql_database_instance" "postgres" {
+  name             = var.db_name
+  database_version = var.db_version
+  region           = var.region
+
+  settings {
+    tier = var.tier
+  }
+
+  deletion_protection = false
+  root_password       = var.db_password
+}
+
+resource "google_sql_database" "default" {
+  name     = var.db_name
+  instance = google_sql_database_instance.postgres.name
+}
+
+output "host" {
+  value = google_sql_database_instance.postgres.ip_address[0].ip_address
+}
+
+output "port" { value = 5432 }
+output "user" { value = "postgres" }
+output "password" { value = var.db_password }
+output "db_name" { value = var.db_name }

--- a/modules/gcp_redis/main.tf
+++ b/modules/gcp_redis/main.tf
@@ -1,0 +1,15 @@
+variable "project" { type = string }
+variable "region" { type = string }
+variable "name" { type = string }
+variable "tier" { type = string }
+variable "memory_size_gb" { type = number }
+
+resource "google_redis_instance" "redis" {
+  name           = var.name
+  tier           = var.tier
+  memory_size_gb = var.memory_size_gb
+  region         = var.region
+}
+
+output "host" { value = google_redis_instance.redis.host }
+output "port" { value = google_redis_instance.redis.port }


### PR DESCRIPTION
## Summary
- add README with instructions for Google Cloud
- add new OpenTofu configuration for Google Cloud
- implement supporting modules for GCP resources

## Testing
- `tofu validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e823df18832780655ec4a1727b3b