### PR TITLE
Add GCP deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Deploy a production-ready ChirpStack instance with all its core dependencies usi
 - **Load Balancer** for routing external traffic
 
 > ⚡ Deploy to Digital Ocean
+
+## 🚀 Deploy to Google Cloud Platform
+
+A new `main_gcp.tf` configuration and accompanying modules allow deploying the same stack on GCP. Configure your project ID, region and zone along with the machine sizes and credentials, then run `tofu init && tofu apply` in the repository root.

--- a/main_gcp.tf
+++ b/main_gcp.tf
@@ -1,0 +1,155 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# GCP variables
+variable "gcp_project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "gcp_region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "gcp_zone" {
+  description = "GCP zone"
+  type        = string
+}
+
+variable "network_name" {
+  type        = string
+  description = "VPC network name"
+  default     = "lorawan-network"
+}
+
+variable "firewall_name" {
+  type        = string
+  default     = "ssh-firewall"
+}
+
+variable "redis_instance_name" {
+  type = string
+  default = "redis"
+}
+
+variable "redis_machine_type" {
+  type    = string
+  default = "e2-medium"
+}
+
+variable "redis_password" {
+  type = string
+}
+
+variable "mosquitto_instance_name" {
+  type    = string
+  default = "mosquitto"
+}
+
+variable "mosquitto_machine_type" {
+  type    = string
+  default = "e2-medium"
+}
+
+variable "mosquitto_username" { type = string }
+variable "mosquitto_password" { type = string }
+
+variable "chirpstack_machine_type" {
+  type    = string
+  default = "e2-medium"
+}
+
+variable "chirpstack_count" {
+  type    = number
+  default = 2
+}
+
+variable "db_name" {
+  type    = string
+  default = "lorawan-db"
+}
+
+variable "db_user" {
+  type    = string
+  default = "lorawan"
+}
+
+variable "db_password" { type = string }
+
+# Modules
+module "network" {
+  source          = "./modules_gcp/network"
+  gcp_project     = var.gcp_project
+  gcp_region      = var.gcp_region
+  gcp_network_name = var.network_name
+  gcp_firewall_name = var.firewall_name
+}
+
+module "redis" {
+  source             = "./modules_gcp/redis"
+  gcp_project        = var.gcp_project
+  gcp_zone           = var.gcp_zone
+  redis_instance_name = var.redis_instance_name
+  machine_type        = var.redis_machine_type
+  redis_password      = var.redis_password
+  network_self_link   = module.network.network_self_link
+}
+
+module "postgres" {
+  source      = "./modules_gcp/postgres"
+  gcp_project = var.gcp_project
+  gcp_region  = var.gcp_region
+  db_name     = var.db_name
+  db_user     = var.db_user
+  db_password = var.db_password
+}
+
+module "mosquitto" {
+  source               = "./modules_gcp/mosquitto"
+  gcp_project          = var.gcp_project
+  gcp_zone             = var.gcp_zone
+  mosquitto_instance_name = var.mosquitto_instance_name
+  machine_type            = var.mosquitto_machine_type
+  mosquitto_username      = var.mosquitto_username
+  mosquitto_password      = var.mosquitto_password
+  network_self_link       = module.network.network_self_link
+}
+
+module "chirpstack" {
+  source            = "./modules_gcp/chirpstack"
+  gcp_project       = var.gcp_project
+  gcp_zone          = var.gcp_zone
+  instance_count    = var.chirpstack_count
+  machine_type      = var.chirpstack_machine_type
+  network_self_link = module.network.network_self_link
+  mosquitto_host     = module.mosquitto.mosquitto_host
+  mosquitto_port     = module.mosquitto.mosquitto_port
+  mosquitto_username = var.mosquitto_username
+  mosquitto_password = var.mosquitto_password
+  postgres_host      = module.postgres.postgres_host
+  postgres_port      = module.postgres.postgres_port
+  postgres_db_name   = module.postgres.postgres_db_name
+  postgres_user      = module.postgres.postgres_user
+  postgres_password  = module.postgres.postgres_password
+  redis_host         = module.redis.redis_host
+  redis_password     = module.redis.redis_password
+}
+
+module "loadbalancer" {
+  source        = "./modules_gcp/loadbalancer"
+  gcp_project   = var.gcp_project
+  gcp_region    = var.gcp_region
+  instance_ips  = module.chirpstack.chirpstack_instance_ips
+  lb_name       = "lorawan-lb"
+}
+
+output "loadbalancer_ip" {
+  value = module.loadbalancer.lb_ip
+}

--- a/modules_gcp/chirpstack/main.tf
+++ b/modules_gcp/chirpstack/main.tf
@@ -1,0 +1,77 @@
+variable "gcp_project" {
+  type = string
+}
+
+variable "gcp_zone" {
+  type = string
+}
+
+variable "instance_count" {
+  type    = number
+  default = 1
+}
+
+variable "machine_type" {
+  type = string
+}
+
+variable "network_self_link" {
+  type = string
+}
+
+variable "mosquitto_host" { type = string }
+variable "mosquitto_port" { type = number }
+variable "mosquitto_username" { type = string }
+variable "mosquitto_password" { type = string }
+
+variable "postgres_host" { type = string }
+variable "postgres_port" { type = number }
+variable "postgres_db_name" { type = string }
+variable "postgres_user" { type = string }
+variable "postgres_password" { type = string }
+
+variable "redis_host" { type = string }
+variable "redis_password" { type = string }
+
+provider "google" {
+  project = var.gcp_project
+  zone    = var.gcp_zone
+}
+
+resource "google_compute_instance" "chirpstack" {
+  count        = var.instance_count
+  name         = "chirpstack-${count.index}"
+  machine_type = var.machine_type
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+    }
+  }
+
+  network_interface {
+    network = var.network_self_link
+    access_config {}
+  }
+
+  metadata_startup_script = <<-EOT
+    #!/bin/bash
+    set -eux
+    apt-get update -y
+    apt-get install -y docker.io docker-compose git
+    git clone https://github.com/tofuhubhq/chirpstack-docker.git /opt/chirpstack
+    cat <<EOFENV >/opt/chirpstack/.env
+MQTT_BROKER_HOST=${var.mosquitto_username}:${var.mosquitto_password}@${var.mosquitto_host}
+POSTGRESQL_HOST=postgres://${var.postgres_user}:${var.postgres_password}@${var.postgres_host}:${var.postgres_port}/${var.postgres_db_name}?sslmode=disable
+REDIS_HOST=default:${var.redis_password}@${var.redis_host}
+EOFENV
+    cd /opt/chirpstack
+    docker-compose up --build -d
+  EOT
+
+  tags = ["chirpstack"]
+}
+
+output "chirpstack_instance_ips" {
+  value = [for i in google_compute_instance.chirpstack : i.network_interface[0].access_config[0].nat_ip]
+}

--- a/modules_gcp/loadbalancer/main.tf
+++ b/modules_gcp/loadbalancer/main.tf
@@ -1,0 +1,61 @@
+variable "gcp_project" { type = string }
+variable "gcp_region" { type = string }
+variable "instance_ips" { type = list(string) }
+variable "lb_name" { type = string }
+
+provider "google" {
+  project = var.gcp_project
+  region  = var.gcp_region
+}
+
+resource "google_compute_health_check" "http" {
+  name               = "${var.lb_name}-hc"
+  check_interval_sec = 10
+  http_health_check {
+    port = 8080
+  }
+}
+
+resource "google_compute_instance_group" "group" {
+  name    = "${var.lb_name}-group"
+  zone    = "${var.gcp_region}-a"
+
+  instances = [for ip in var.instance_ips : ip]
+
+  named_port {
+    name = "http"
+    port = 8080
+  }
+}
+
+resource "google_compute_backend_service" "default" {
+  name                    = "${var.lb_name}-backend"
+  protocol                = "HTTP"
+  health_checks           = [google_compute_health_check.http.id]
+  timeout_sec             = 10
+  port_name               = "http"
+  connection_draining_timeout_sec = 0
+  backend {
+    group = google_compute_instance_group.group.self_link
+  }
+}
+
+resource "google_compute_url_map" "map" {
+  name            = "${var.lb_name}-map"
+  default_service = google_compute_backend_service.default.self_link
+}
+
+resource "google_compute_target_http_proxy" "proxy" {
+  name   = "${var.lb_name}-proxy"
+  url_map = google_compute_url_map.map.self_link
+}
+
+resource "google_compute_global_forwarding_rule" "fr" {
+  name       = "${var.lb_name}-fr"
+  target     = google_compute_target_http_proxy.proxy.self_link
+  port_range = "80"
+}
+
+output "lb_ip" {
+  value = google_compute_global_forwarding_rule.fr.ip_address
+}

--- a/modules_gcp/mosquitto/main.tf
+++ b/modules_gcp/mosquitto/main.tf
@@ -1,0 +1,73 @@
+variable "gcp_project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "gcp_zone" {
+  description = "GCP compute zone"
+  type        = string
+}
+
+variable "mosquitto_instance_name" {
+  description = "Name of the mosquitto instance"
+  type        = string
+}
+
+variable "machine_type" {
+  description = "Compute machine type"
+  type        = string
+}
+
+variable "mosquitto_username" {
+  type        = string
+}
+
+variable "mosquitto_password" {
+  type        = string
+}
+
+variable "network_self_link" {
+  type = string
+}
+
+provider "google" {
+  project = var.gcp_project
+  zone    = var.gcp_zone
+}
+
+resource "google_compute_instance" "mosquitto" {
+  name         = var.mosquitto_instance_name
+  machine_type = var.machine_type
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+    }
+  }
+
+  network_interface {
+    network = var.network_self_link
+    access_config {}
+  }
+
+  metadata_startup_script = <<-EOT
+    #!/bin/bash
+    apt-get update -y
+    apt-get install -y mosquitto
+    mosquitto_passwd -b -c /etc/mosquitto/passwd "${var.mosquitto_username}" "${var.mosquitto_password}"
+    echo "allow_anonymous false" > /etc/mosquitto/conf.d/auth.conf
+    echo "password_file /etc/mosquitto/passwd" >> /etc/mosquitto/conf.d/auth.conf
+    systemctl restart mosquitto
+    systemctl enable mosquitto
+  EOT
+
+  tags = ["mosquitto"]
+}
+
+output "mosquitto_host" {
+  value = google_compute_instance.mosquitto.network_interface[0].access_config[0].nat_ip
+}
+
+output "mosquitto_port" {
+  value = 1883
+}

--- a/modules_gcp/network/main.tf
+++ b/modules_gcp/network/main.tf
@@ -1,0 +1,49 @@
+variable "gcp_project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "gcp_region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "gcp_network_name" {
+  description = "Name of VPC network"
+  type        = string
+}
+
+variable "gcp_firewall_name" {
+  description = "Name of SSH firewall rule"
+  type        = string
+}
+
+provider "google" {
+  project = var.gcp_project
+  region  = var.gcp_region
+}
+
+resource "google_compute_network" "vpc" {
+  name                    = var.gcp_network_name
+  auto_create_subnetworks = true
+}
+
+resource "google_compute_firewall" "ssh" {
+  name    = var.gcp_firewall_name
+  network = google_compute_network.vpc.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "network_name" {
+  value = google_compute_network.vpc.name
+}
+
+output "network_self_link" {
+  value = google_compute_network.vpc.self_link
+}

--- a/modules_gcp/postgres/main.tf
+++ b/modules_gcp/postgres/main.tf
@@ -1,0 +1,71 @@
+variable "gcp_project" {
+  type = string
+}
+
+variable "gcp_region" {
+  type = string
+}
+
+variable "db_name" {
+  type = string
+}
+
+variable "db_tier" {
+  type    = string
+  default = "db-f1-micro"
+}
+
+variable "db_user" {
+  type = string
+}
+
+variable "db_password" {
+  type = string
+}
+
+provider "google" {
+  project = var.gcp_project
+  region  = var.gcp_region
+}
+
+resource "google_sql_database_instance" "postgres" {
+  name             = var.db_name
+  database_version = "POSTGRES_14"
+  region           = var.gcp_region
+
+  settings {
+    tier = var.db_tier
+  }
+}
+
+resource "google_sql_user" "default" {
+  name     = var.db_user
+  instance = google_sql_database_instance.postgres.name
+  password = var.db_password
+}
+
+resource "google_sql_database" "db" {
+  name     = var.db_name
+  instance = google_sql_database_instance.postgres.name
+}
+
+output "postgres_host" {
+  value = google_sql_database_instance.postgres.public_ip_address
+}
+
+output "postgres_port" {
+  value = 5432
+}
+
+output "postgres_user" {
+  value = google_sql_user.default.name
+}
+
+output "postgres_password" {
+  value     = var.db_password
+  sensitive = true
+}
+
+output "postgres_db_name" {
+  value = google_sql_database.db.name
+}

--- a/modules_gcp/redis/main.tf
+++ b/modules_gcp/redis/main.tf
@@ -1,0 +1,72 @@
+variable "gcp_project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "gcp_zone" {
+  description = "GCP compute zone"
+  type        = string
+}
+
+variable "redis_instance_name" {
+  description = "Name of the redis instance"
+  type        = string
+}
+
+variable "machine_type" {
+  description = "Compute machine type"
+  type        = string
+}
+
+variable "redis_password" {
+  description = "Password for redis"
+  type        = string
+}
+
+variable "network_self_link" {
+  description = "VPC self link"
+  type        = string
+}
+
+provider "google" {
+  project = var.gcp_project
+  zone    = var.gcp_zone
+}
+
+resource "google_compute_instance" "redis" {
+  name         = var.redis_instance_name
+  machine_type = var.machine_type
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+    }
+  }
+
+  network_interface {
+    network = var.network_self_link
+    access_config {}
+  }
+
+  metadata_startup_script = <<-EOT
+    #!/bin/bash
+    apt-get update -y
+    apt-get install -y redis-server
+    sed -i "s/^#\\?requirepass .*/requirepass ${var.redis_password}/" /etc/redis/redis.conf
+    sed -i "s/^bind .*/bind 0.0.0.0/" /etc/redis/redis.conf
+    sed -i "s/^protected-mode .*/protected-mode no/" /etc/redis/redis.conf
+    systemctl enable redis-server
+    systemctl restart redis-server
+  EOT
+
+  tags = ["redis"]
+}
+
+output "redis_host" {
+  value = google_compute_instance.redis.network_interface[0].access_config[0].nat_ip
+}
+
+output "redis_password" {
+  value     = var.redis_password
+  sensitive = true
+}


### PR DESCRIPTION
## Summary
- create Terraform modules for deploying on Google Cloud Platform
- add `main_gcp.tf` configuration
- document the new GCP deployment in README

## Testing
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a0c2b11f8832794d32b551caef1f7